### PR TITLE
Fix Heroku deployment by adding Node.js engine specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
       "last 1 safari version"
     ]
   },
+  "engines": {
+    "node": "18.x",
+    "npm": "9.x"
+  },
   "devDependencies": {
     "@babel/core": "^7.18.9",
     "@babel/eslint-parser": "^7.18.9",


### PR DESCRIPTION
## Summary
Fixes Heroku deployment issue where the build was failing with heroku-24 stack incompatibility.

## Changes
- Added Node.js engine specification to package.json (Node 18.x, npm 9.x)
- This ensures compatibility with Heroku's build system

## Problem
The deployment was failing with:
- "Stack heroku-24 is not supported!"
- "Push rejected, failed to compile React.js (create-react-app) multi app"

## Solution
By specifying the Node.js version in package.json, Heroku can properly detect and use the correct buildpack configuration. Users will also need to set their Heroku stack to heroku-22 using:
```bash
heroku stack:set heroku-22 --app [app-name]
```

## Test plan
- [ ] Verify package.json has correct engine specification
- [ ] Deploy to Heroku with heroku-22 stack
- [ ] Confirm build succeeds and app runs properly

🤖 Generated with [Claude Code](https://claude.ai/code)