### PR TITLE
Add Procfile for Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node server.js


### PR DESCRIPTION
## Summary
Adds missing Procfile that's required for Heroku to properly detect and deploy the Node.js application.

## Problem
After merging PR #88, Heroku deployment still fails with:
- "Detected Framework: Static HTML"
- "Stack heroku-22 is not supported!"
- "Push rejected, failed to compile React.js (create-react-app) multi app"

The issue is that without a Procfile, Heroku doesn't recognize this as a Node.js application and tries to use the static buildpack instead.

## Solution
Added `Procfile` with the command: `web: node server.js`

This explicitly tells Heroku:
1. This is a web application
2. Use Node.js to run `server.js`
3. This ensures proper buildpack detection

## Deployment Steps After Merge
```bash
# Clear any existing buildpacks
heroku buildpacks:clear --app YOUR-APP-NAME

# Set Node.js buildpack explicitly
heroku buildpacks:set heroku/nodejs --app YOUR-APP-NAME

# Deploy
git push heroku dev:main
```

## Test Plan
- [ ] Merge this PR
- [ ] Deploy to Heroku
- [ ] Verify Heroku detects "Node.js app detected" instead of "Static HTML"
- [ ] Confirm deployment succeeds without deprecated buildpack warnings

🤖 Generated with [Claude Code](https://claude.ai/code)