### PR TITLE
Fix: Set Node.js to version 22.x for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ]
   },
   "engines": {
-    "node": ">=20.x",
+    "node": "22.x",
     "npm": ">=10.x"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- Changed Node.js engine requirement from `>=20.x` to `22.x`
- This fix was needed but missed in PR #95

## Problem
The deployment platform shows error: "Node.js Version 18.x is discontinued and must be upgraded"

## Solution
Set explicit Node.js version to 22.x as required by the deployment platform

## Test plan
- [x] Package.json updated with correct Node.js version
- [ ] Deploy to Vercel/Heroku to verify the error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)