### PR TITLE
Sync package-lock.json with Node.js 22.x requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "stylelint-scss": "^6.0.0"
       },
       "engines": {
-        "node": ">=20.x",
+        "node": "22.x",
         "npm": ">=10.x"
       }
     },


### PR DESCRIPTION
## Summary
- Syncs package-lock.json to match package.json Node.js version requirement
- Updates Node.js engine from `>=20.x` to `22.x` in package-lock.json

## Context
PR #96 updated package.json to use Node.js 22.x but package-lock.json was not synced.

## Changes
- package-lock.json: Node.js engine requirement updated from `>=20.x` to `22.x`

## Test plan
- [x] npm install runs successfully
- [x] package.json and package-lock.json are now consistent
- [ ] Deployment should work without Node.js version errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)